### PR TITLE
fix off by 1 error in inclusion proof

### DIFF
--- a/logverification/app/appentry.go
+++ b/logverification/app/appentry.go
@@ -263,7 +263,7 @@ func (ae *AppEntry) Proof(massifContext *massifs.MassifContext) ([][]byte, error
 	// Get the size of the complete tenant MMR
 	mmrSize := massifContext.RangeCount()
 
-	proof, err := mmr.InclusionProof(massifContext, mmrSize-1, ae.MMRIndex())
+	proof, err := mmr.InclusionProof(massifContext, mmrSize, ae.MMRIndex())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Overview
* veracity testing shows we had an off by one

## Testing

tested prod assetsv2 event inclusion verification using veracity:

```
=== RUN   TestVerifyEventsSuite
    /home/jgough/workspace/veracity/tests/verifyincluded/suite.go:234: warning: no tests to run
--- PASS: TestVerifyEventsSuite (0.00s)
PASS
ok      github.com/datatrails/veracity/tests/verifyincluded     0.008s 
```

re: AB#10216