### PR TITLE
Fix every alternate entry failing due to thinking the last index entry is greater than it is.

### DIFF
--- a/logverification/app/appentry.go
+++ b/logverification/app/appentry.go
@@ -263,7 +263,7 @@ func (ae *AppEntry) Proof(massifContext *massifs.MassifContext) ([][]byte, error
 	// Get the size of the complete tenant MMR
 	mmrSize := massifContext.RangeCount()
 
-	proof, err := mmr.InclusionProof(massifContext, mmrSize, ae.MMRIndex())
+	proof, err := mmr.InclusionProof(massifContext, mmrSize-1, ae.MMRIndex())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Overview
* Fix every alternate entry failing due to thinking the last index entry is greater than it is.

## Testing

Validated by running the eventsv1 forestrie systest multiple times:

```
PASS
ok  	github.com/datatrails/forestrie/systests/e2eintegrity	1.651s
```

re: AB#10376